### PR TITLE
feat: change from node:11-slim to node:11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM node:11-slim
+FROM node:11
 
-LABEL version="1.0.0"
+LABEL version="1.1.0"
 LABEL repository="https://github.com/nuxt/actions-yarn"
 LABEL homepage="https://github.com/nuxt/actions-yarn"
 LABEL maintainer="Xin Du (Clark) <clark.duxin@gmail.com>"
@@ -9,7 +9,7 @@ LABEL com.github.actions.name="GitHub Action for Yarn"
 LABEL com.github.actions.description="Wraps the yarn CLI to enable common yarn commands."
 LABEL com.github.actions.icon="package"
 LABEL com.github.actions.color="red"
-# COPY LICENSE README.md THIRD_PARTY_NOTICE.md /
+COPY LICENSE README.md /
 
 COPY "entrypoint.sh" "/entrypoint.sh"
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Using `node:X-slim` without further customization breaks some uses of node, like `node-gyp` (which, if it needs to compile, uses packages from the non-slim `node` images. This changes to the non-slim version to match [`actions/npm`](https://github.com/actions/npm).